### PR TITLE
Creds: Kanboard 1.0.37

### DIFF
--- a/creds/web/kanboard_1037.yml
+++ b/creds/web/kanboard_1037.yml
@@ -1,0 +1,29 @@
+auth:
+  credentials:
+  - password: admin
+    username: admin
+  csrf: csrf_token
+  post:
+    password: password
+    remember_me: '1'
+    username: username
+  sessionid: KB_SID
+  success:
+    body: 
+    - Dashboard for admin
+    status: 200
+  type: post
+  url:
+  - /?controller=AuthController&action=check
+  - /kanboard/?controller=AuthController&action=check
+category: web
+contributor: ztgrace, ThomasTJdev
+default_port: 80
+fingerprint:
+  body: /?controller=AuthController&amp;action=check
+  status: 200
+  url:
+  - /?controller=AuthController&action=login
+  - /kanboard/?controller=AuthController&action=login
+name: Kanboard_1037
+ssl: false


### PR DESCRIPTION
## Kanboard 1.0.37
Current creds for Kanboard, `kanboard.yml`, does not work on the newest release of Kanboard 1.0.37.

## Problem & Solution
After Kanboards upgrade (May 28, 2016 - 1353929a7dbd3f2e897fa7d3ab88e959ca573f9f) the authentication controller has been renamed from:
`auth` to `AuthController`

There is nothing in the body which matches the current `<title>Dashboard</title>` therefore I have changed this to: `Dashboard for admin`.

## Further development
@ztgrace - What are your thoughts on multiple versions/releases of the same software? Should these new versions be included in the same file, or would you like multiple files like this pull?