### PR TITLE
Adds required -dev dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ RUN apk add --no-cache --virtual .changeme-deps \
         py-pip \
     && apk add --no-cache --virtual .build-deps \
         libxml2-dev \
+        python-dev \
+	    libffi-dev \
+	    musl-dev \
+	    openssl-dev \
         gcc \
     && pip install -r /changeme/requirements.txt \
     && apk del .build-deps \


### PR DESCRIPTION
Resolves #23 

This adds the missing -dev dependencies for `cffi` and `cryptography` packages. Added to build-deps so the image is only 92MB built.

Let me know if anything doesn't look right.