### PR TITLE
Added creds/http/general/ubiquiti_edgeos.yml

### DIFF
--- a/creds/http/general/ubiquiti_edgeos.yml
+++ b/creds/http/general/ubiquiti_edgeos.yml
@@ -1,0 +1,28 @@
+auth:
+  credentials:
+  - username: ubnt
+    password: ubnt
+  post:
+    username: username
+    password: password
+  sessionid: PHPSESSID
+  success:
+    body:
+      - Please wait while the application loads
+    status: 200
+  type: post
+  url:
+    - /
+  headers:
+    - Content-Type: application/x-www-form-urlencoded
+category: web
+contributor: Gijutsu
+fingerprint:
+  body:
+    - <title>EdgeOS</title>
+  status: 200
+  url:
+    - /
+name: Ubiquiti EdgeOS
+default_port: 443
+ssl: true


### PR DESCRIPTION
These are the default credentials used for the built-in admin user ubnt in EdgeOS for EdgeRouters from the manufacturer Ubiquiti Networks.