### PR TITLE
v1.0.4 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A default credential scanner.
 
 ## About
 
-I wrote changeme out of frustration with commercial vulnerability scanners missing common default credentials. Getting default credentials added to commercial scanners is often difficult and slow. changeme is designed to be simple to add new credentials without having to write any code or modules.
+changeme picks up where commercial scanners leave off. It focuses on detecting default and backdoor credentials and not necessarily common credentials. It's default mode is to scan HTTP default credentials, but has support for other credentials.
 
-changeme keeps credential data separate from code. All credentials are stored in [yaml](http://yaml.org/) files so they can be both easily read by humans and processed by changeme. Credential files can be created by using the `./changeme.py --mkcred` tool and answering a few questions.
+changeme is designed to be simple to add new credentials without having to write any code or modules. changeme keeps credential data separate from code. All credentials are stored in [yaml](http://yaml.org/) files so they can be both easily read by humans and processed by changeme. Credential files can be created by using the `./changeme.py --mkcred` tool and answering a few questions.
 
 changeme supports the http/https, mssql, mysql, postgres, ssh, ssh w/key, snmp, mongodb and ftp protocols. Use `./changeme.py --dump` to output all of the currently available credentials.
 
@@ -14,7 +14,7 @@ You can load your targets using a variety of methods, single ip address/host, su
 
 ## Installation
 
-changeme has only been tested on Linux and has known issues on Windows and OS X/macOS. Use docker to run changeme on the unsupported platforms.
+changeme has only been tested on Linux and has known issues on Windows and OS X/macOS. Use docker to run changeme on the unsupported platforms. It supports either a redis-backed queue (most stable) or an in-memory backed queue.
 
 Stable versions of changeme can be found on the [releases](https://github.com/ztgrace/changeme/releases) page.
 

--- a/changeme/scanners/http_fingerprint.py
+++ b/changeme/scanners/http_fingerprint.py
@@ -11,13 +11,14 @@ import requests
 
 
 class HttpFingerprint:
-    def __init__(self, target, headers, cookies, config, creds):
+    def __init__(self, target, headers, cookies, config):
         self.target = target # changeme.target.Target()
         self.headers = headers
         self.cookies = cookies
         self.config = config
-        self.creds = creds
         self.logger = logging.getLogger('changeme')
+        self.res = None
+        self.req = requests.Session()
 
     def __getstate__(self):
         state = self.__dict__
@@ -35,11 +36,9 @@ class HttpFingerprint:
         return self.__dict__ == other.__dict__
 
     def fingerprint(self):
-        scanners = list()
-        s = requests.Session()
 
         try:
-            res = s.get(
+            self.res = self.req.get(
                 str(self.target),
                 timeout=self.config.timeout,
                 verify=False,
@@ -49,37 +48,9 @@ class HttpFingerprint:
             )
         except Exception as e:
             self.logger.debug('Failed to connect to %s' % self.target)
-            return
+            return False
 
-        for cred in self.creds:
-            if self.ismatch(cred, res):
-
-                csrf = self._get_csrf_token(res, cred)
-                if cred['auth'].get('csrf', False) and not csrf:
-                    self.logger.error('Missing required CSRF token')
-                    return
-
-                sessionid = self._get_session_id(res, cred)
-                if cred['auth'].get('sessionid') and not sessionid:
-                    self.logger.error("Missing session cookie %s for %s" % (cred['auth'].get('sessionid'), res.url))
-                    return
-
-                for pair in cred['auth']['credentials']:
-                    for u in cred['auth']['url']:  # pass in the auth url
-                        target = deepcopy(self.target)
-                        target.url = u
-                        self.logger.debug('Building %s %s:%s, %s' % (cred['name'], pair['username'], pair['password'], target))
-
-                        if cred['auth']['type'] == 'get':
-                            scanners.append(HTTPGetScanner(cred, target, pair['username'], pair['password'], self.config, s.cookies))
-                        elif cred['auth']['type'] == 'post':
-                            scanners.append(HTTPPostScanner(cred, target, pair['username'], pair['password'], self.config, s.cookies, csrf))
-                        elif cred['auth']['type'] == 'raw_post':
-                            scanners.append(HTTPRawPostScanner(cred, target, pair['username'], pair['password'], self.config, s.cookies, csrf, pair['raw']))
-                        elif cred['auth']['type'] == 'basic_auth':
-                            scanners.append(HTTPBasicAuthScanner(cred, target, pair['username'], pair['password'], self.config, s.cookies))
-
-        return scanners
+        return True
 
     def _get_csrf_token(self, res, cred):
         name = cred['auth'].get('csrf', False)
@@ -139,6 +110,38 @@ class HttpFingerprint:
 
         return match
 
+    def get_scanners(self, creds):
+        scanners = list()
+        for cred in creds:
+            if self.ismatch(cred, self.res):
+
+                csrf = self._get_csrf_token(self.res, cred)
+                if cred['auth'].get('csrf', False) and not csrf:
+                    self.logger.error('Missing required CSRF token')
+                    return
+
+                sessionid = self._get_session_id(self.res, cred)
+                if cred['auth'].get('sessionid') and not sessionid:
+                    self.logger.error("Missing session cookie %s for %s" % (cred['auth'].get('sessionid'), self.res.url))
+                    return
+
+                for pair in cred['auth']['credentials']:
+                    for u in cred['auth']['url']:  # pass in the auth url
+                        target = deepcopy(self.target)
+                        target.url = u
+                        self.logger.debug('Building %s %s:%s, %s' % (cred['name'], pair['username'], pair['password'], target))
+
+                        if cred['auth']['type'] == 'get':
+                            scanners.append(HTTPGetScanner(cred, target, pair['username'], pair['password'], self.config, self.req.cookies))
+                        elif cred['auth']['type'] == 'post':
+                            scanners.append(HTTPPostScanner(cred, target, pair['username'], pair['password'], self.config, self.req.cookies, csrf))
+                        elif cred['auth']['type'] == 'raw_post':
+                            scanners.append(HTTPRawPostScanner(cred, target, pair['username'], pair['password'], self.config, self.req.cookies, csrf, pair['raw']))
+                        elif cred['auth']['type'] == 'basic_auth':
+                            scanners.append(HTTPBasicAuthScanner(cred, target, pair['username'], pair['password'], self.config, self.req.cookies))
+
+        return scanners
+
     @staticmethod
     def build_fingerprints(targets, creds, config):
         fingerprints = list()
@@ -163,13 +166,7 @@ class HttpFingerprint:
                         t.port = c['default_port']
                     t.url = url
 
-                    hfp = HttpFingerprint(
-                        t,
-                        fp.get('headers', None),
-                        fp.get('cookie', None),
-                        config,
-                        creds,
-                    )
+                    hfp = HttpFingerprint(t, fp.get('headers', None), fp.get('cookie', None), config)
                     logger.debug('Adding %s to fingerprint list' % hfp.target)
                     fingerprints.append(hfp)
 

--- a/changeme/scanners/http_fingerprint.py
+++ b/changeme/scanners/http_fingerprint.py
@@ -33,7 +33,7 @@ class HttpFingerprint:
         return hash(str(self.target) + str(self.headers) + str(self.cookies))
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        return self.target == other.target
 
     def fingerprint(self):
 

--- a/changeme/scanners/scanner.py
+++ b/changeme/scanners/scanner.py
@@ -29,16 +29,22 @@ class Scanner(object):
             result = sock.connect_ex((str(self.target.host), self.target.port))
             sock.shutdown(2)
             if result == 0:
+                return True
                 self.logger.info('Port %i open' % self.target.port)
-                scanners = list()
-                for pair in self.cred['auth']['credentials']:
-                    scanners.append(self._mkscanner(self.cred, self.target, pair['username'], pair['password'], self.config))
-                return scanners
             else:
                 return False
         except Exception as e:
             self.logger.debug(str(e))
             return False
+
+    def get_scanners(self, creds):
+        scanners = list()
+        for pair in self.cred['auth']['credentials']:
+
+            scanners.append(self._mkscanner(self.cred, self.target, pair['username'], pair['password'], self.config))
+            self.logger.warning(self._mkscanner(self.cred, self.target, pair['username'], pair['password'], self.config))
+        return scanners
+
 
     def check_success(self):
         try:

--- a/changeme/scanners/snmp.py
+++ b/changeme/scanners/snmp.py
@@ -7,11 +7,8 @@ class SNMP(Scanner):
         super(SNMP, self).__init__(cred, target, config, username, password)
 
     def fingerprint(self):
-        # Just build the scanners instead of mess around detecting the UDP service
-        scanners = list()
-        for pair in self.cred['auth']['credentials']:
-            scanners.append(self._mkscanner(self.cred, self.target, None, pair['password'], self.config))
-        return scanners
+        # Don't fingerprint since it's UDP
+        return True
 
     def _check(self):
         iterator = getCmd(SnmpEngine(),

--- a/changeme/tests/http.py
+++ b/changeme/tests/http.py
@@ -123,14 +123,18 @@ def test_jboss_scan_fail(mock_args):
     scanners = list()
     while se.scanners.qsize() > 0:
         s = se.scanners.get()
-        print s.target
-        print s.username
-        print s.password
+        print(s.cred['name'])
+        print(s.target)
+        print(s.username)
+        print(s.password)
         scanners.append(s)
 
-    print("len: %i" % len(set(scanners)))
+    print("num scanners: %i" % len(scanners))
+    assert len(scanners) == 2
 
-    assert se.scanners.qsize() == 2
+    # put scanners back in queue
+    for s in scanners:
+        se.scanners.put(s)
 
     se._scan(se.scanners, se.found_q)
     assert se.found_q.qsize() == 0

--- a/changeme/tests/http.py
+++ b/changeme/tests/http.py
@@ -120,6 +120,16 @@ def test_jboss_scan_fail(mock_args):
     se._build_targets()
     se.fingerprint_targets(se.fingerprints, se.scanners)
     print(se.scanners.qsize())
+    scanners = list()
+    while se.scanners.qsize() > 0:
+        s = se.scanners.get()
+        print s.target
+        print s.username
+        print s.password
+        scanners.append(s)
+
+    print("len: %i" % len(set(scanners)))
+
     assert se.scanners.qsize() == 2
 
     se._scan(se.scanners, se.found_q)

--- a/changeme/version.py
+++ b/changeme/version.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 contributors = [
     "ztgrace",
     "the-c0d3r",

--- a/creds/http/general/apache_tomcat_host_manager.yml
+++ b/creds/http/general/apache_tomcat_host_manager.yml
@@ -1,0 +1,51 @@
+auth:
+  credentials:
+  - username: tomcat
+    password: tomcat
+  - username: admin
+    password: admin
+  - username: ovwebusr
+    password: OvW*busr1
+  - username: j2deployer
+    password: j2deployer
+  - username: cxsdk
+    password: kdsxc
+  - username: ADMIN
+    password: ADMIN
+  - username: xampp
+    password: xampp
+  - username: tomcat
+    password: s3cret
+  - username: QCC
+    password: QLogic66
+  - username: admin
+    password:
+  - username: admin
+    password: tomcat
+  - username: root
+    password: root
+  - username: role1
+    password: role1
+  - username: role
+    password: changethis
+  - username: tomcat
+    password: changethis
+  - username: admin
+    password: j5Brn9
+  - username: role1
+    password: tomcat
+  success:
+    status: 200
+  type: basic_auth
+  url:
+  - /host-manager/html
+category: web
+contributor: anshumanbh
+default_port: 8080
+fingerprint:
+  basic_auth_realm: Tomcat Host Manager Application
+  status: 401
+  url:
+  - /host-manager/html
+name: Apache Tomcat Host Manager
+ssl: false

--- a/creds/http/general/kanboard.yml
+++ b/creds/http/general/kanboard.yml
@@ -1,0 +1,28 @@
+auth:
+  credentials:
+  - password: admin
+    username: admin
+  csrf: csrf_token
+  post:
+    password: password
+    remember_me: '1'
+    username: username
+  sessionid: KB_SID
+  success:
+    body: 
+    - <title>Dashboard</title>
+    status: 200
+  type: post
+  url:
+  - /?controller=auth&action=check
+category: web
+contributor: ztgrace
+default_port: 80
+fingerprint:
+  body: 
+  - /?controller=auth&amp;action=check
+  status: 200
+  url:
+  - /?controller=auth&action=login
+name: Kanboard
+ssl: false

--- a/creds/http/general/makito_decoder.yml
+++ b/creds/http/general/makito_decoder.yml
@@ -1,0 +1,28 @@
+auth:
+  credentials:
+  - password: "%89%F0%01%8F%D0%01%80%F0%01%85%D0%01%83%F0%01%83%E0%01%84%F0%01"
+    username: admin
+    ref: http://media.extron.com/download/files/drivers/haiv_44_7036_3.pdf
+  post:
+    action: login
+    md5encrypted: 'no'
+    password: password
+    username: username
+  success:
+    body: 
+    - '>Logout</a'
+    status: 200
+  type: post
+  url:
+  - /cgi-bin/web.cgi
+category: web
+contributor: ztgrace
+default_port: 80
+fingerprint:
+  body: 
+  - <title>MAKITO Login</title>
+  status: 200
+  url:
+  - /cgi-bin/web.cgi
+name: Makito Decoder
+ssl: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ lxml
 netaddr
 nose
 paramiko
-persist-queue==0.3.0
+persist-queue==0.3.1
 psycopg2
 pymongo
 pyodbc


### PR DESCRIPTION
* Fixes database issue for #38 by upgrading persist-queue to 0.3.1 and making the storage mech `:memory:`
* Optimized queue storage for fingerprints by modifying how the `creds` dict is passed to the methods
* Modified to `HttpFingerprint.__eq__` so it's better at uniquing fingerprints
* Added Apache Tomcat Host Manager creds based on #48 
* Re-adding kanboard and makito creds that were accidentally removed during the refactor
