### PR TITLE
Added basic Telnet scanner - #27

### DIFF
--- a/changeme/scan_engine.py
+++ b/changeme/scan_engine.py
@@ -14,6 +14,7 @@ from .scanners.redis_scanner import RedisScanner
 from .scanners.snmp import SNMP
 from .scanners.ssh import SSH
 from .scanners.ssh_key import SSHKey
+from .scanners.telnet import Telnet
 from .scanners.http_fingerprint import HttpFingerprint
 from .target import Target
 import time
@@ -194,6 +195,7 @@ class ScanEngine(object):
             'postgres': 'Postgres',
             'redis': 'RedisScanner',
             'snmp': 'SNMP',
+            'telnet': 'Telnet',
         }
 
         for target in self.targets:

--- a/changeme/scanners/telnet.py
+++ b/changeme/scanners/telnet.py
@@ -1,29 +1,78 @@
 from .scanner import Scanner
 import telnetlib
-
+import re
+import time
 
 class Telnet(Scanner):
 
-    def __init__(self, cred, target, config, username, password):
+    def __init__(self, cred, target, username, password, config):
         super(Telnet, self).__init__(cred, target, config, username, password)
 
     def _check(self):
         try:
-            telnet = telnetlib.Telnet(str(self.target), int(self.port), int(self.config.timeout))
-            telnet.read_until("login: ")
+            telnet = telnetlib.Telnet(str(self.target.host))
+            timeout_allowed = int(self.cred['auth']['blockingio_timeout'])
+            wait_for_pass_prompt = int(self.cred['auth']['telnet_read_timeout'])
+
+            retval = telnet.open(str(self.target.host), int(self.target.port), timeout=timeout_allowed)
+            retval._has_poll = False    # telnetlib hackery :)
+            banner = telnet.read_until("login: ")
             telnet.write(self.username + "\n")
 
-            if self.password:
-                telnet.read_until("Password: ")
-                telnet.write(self.password + "\n")
+            password = str(self.password) if self.password else ''
 
-            # telnet.write("ls\n")
+            result = telnet.read_until("Password: ", timeout=wait_for_pass_prompt)
+            result = Telnet._trim_string(result)
+
+            if "Password:" in result:
+                telnet.write(password + "\n")
+
+            else:
+                self.logger.debug("Check closed at: 1")
+                telnet.close()
+                raise Exception("Telnet credential not found")
+
+            telnet.write(b"ls\n")
+
+            # evidence = '(slow connection, evidence not collected)'
+            # try:
+            #     evidence = telnet.read_all()
+            # except:
+            #     pass
+
+            evidence = "(slow connection, evidence not collected)"
+            time.sleep(3)
+            evidence = telnet.read_very_eager()
+            evidence_fp_check = Telnet._trim_string(evidence)
+
+            self.logger.debug("Evidence string returned (stripped): %s" % str(evidence_fp_check))
+            evidence_fp_check_as_bytes = ":".join("{:02x}".format(ord(c)) for c in evidence_fp_check)
+            self.logger.debug("Evidence string returned (bytes): %s" % str(evidence_fp_check_as_bytes))
+
+            # Remove simple echos or additional password prompt (wrong password)
+            if (not evidence_fp_check) or (evidence_fp_check == "ls") or ("Password:" in evidence) or (evidence == ""):
+                self.logger.debug("Check closed at: 2")
+                telnet.close()
+                raise Exception("Telnet credential not found")
+
+            # Remove additional prompts to login - we have a correct username, but incorrect password
+            if evidence_fp_check.endswith("login:") or evidence_fp_check.endswith("login: "):
+                self.logger.debug("Check closed at: 3")
+                telnet.close()
+                raise Exception("Telnet credential not found")
+
             telnet.write("exit\n")
-            # telnet.read_all()
-            return True
+            telnet.close()
+
+            return evidence
+
         except Exception as e:
-            self.logger.debug('Error: %s' % str(e))
-            return False
+            self.logger.debug("Error: %s" % str(e))
+            raise e
+
+    @staticmethod
+    def _trim_string(str_to_trim):
+        return str(str_to_trim).replace(' ','').replace('\s','').replace('\t','').replace('\r','').replace('\n','')
 
     def _mkscanner(self, cred, target, u, p, config):
         return Telnet(cred, target, u, p, config)

--- a/creds/telnet/telnet.yml
+++ b/creds/telnet/telnet.yml
@@ -1,10 +1,133 @@
+# Mirai botnet credentials from: https://github.com/securing/mirai_credentials/blob/master/mirai_creds.txt
 auth:
   credentials:
   - username: root
     password: password
   - username: root
     password: root
+  - username: root
+    password: xc3511
+  - username: root
+    password: vizxv
+  - username: root
+    password: admin
+  - username: admin
+    password: admin
+  - username: root
+    password: 888888
+  - username: root
+    password: xmhdipc
+  - username: root
+    password: default
+  - username: root
+    password: juantech
+  - username: root
+    password: 123456
+  - username: root
+    password: 54321
+  - username: support
+    password: support
+  - username: root
+    password:
+  - username: admin
+    password: password
+  - username: root
+    password: 12345
+  - username: user
+    password: user
+  - username: admin
+    password:
+  - username: root
+    password: pass
+  - username: admin
+    password: admin1234
+  - username: root
+    password: 1111
+  - username: admin
+    password: smcadmin
+  - username: admin
+    password: 1111
+  - username: root
+    password: 666666
+  - username: root
+    password: 1234
+  - username: root
+    password: klv123
+  - username: Administrator
+    password: admin
+  - username: service
+    password: service
+  - username: supervisor
+    password: supervisor
+  - username: guest
+    password: guest
+  - username: guest
+    password: 12345
+  - username: guest
+    password: 12345
+  - username: admin1
+    password: password
+  - username: administrator
+    password: 1234
+  - username: 666666
+    password: 666666
+  - username: 888888
+    password: 888888
+  - username: ubnt
+    password: ubnt
+  - username: root
+    password: klv1234
+  - username: root
+    password: Zte521
+  - username: root
+    password: hi3518
+  - username: root
+    password: jvbzd
+  - username: root
+    password: anko
+  - username: root
+    password: zlxx.
+  - username: root
+    password: 7ujMko0vizxv
+  - username: root
+    password: 7ujMko0admin
+  - username: root
+    password: system
+  - username: root
+    password: ikwb
+  - username: root
+    password: dreambox
+  - username: root
+    password: user
+  - username: root
+    password: realtek
+  - username: root
+    password: 00000000
+  - username: admin
+    password: 1111111
+  - username: admin
+    password: 1234
+  - username: admin
+    password: 12345
+  - username: admin
+    password: 54321
+  - username: admin
+    password: 123456
+  - username: admin
+    password: 7ujMko0admin
+  - username: admin
+    password: 1234
+  - username: admin
+    password: pass
+  - username: admin
+    password: meinsm
+  - username: tech
+    password: tech
+  - username: mother
+    password: fucker
+  blockingio_timeout: 3
+  telnet_read_timeout: 1
 category: telnet
 default_port: 23
 name: telnet
-contributor: AlessandroZ
+contributor: AlessandroZ, decidedlygray


### PR DESCRIPTION

This PR adds basic Telnet scanner functionality. It also adds Mirai botnet credentials as the default scan creds for telnet.

Telnetlib is not ideal for scanning, but with a little hackery it becomes a "good enough" solution for up to a few hundred hosts.