### PR TITLE
Changing CMD to ENTRYPOINT in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ RUN apk update \
 ENV HOME /changeme
 ENV PS1 "\033[00;34mchangeme>\033[0m "
 WORKDIR /changeme
-CMD ./changeme.py
+ENTRYPOINT ["./changeme.py"]


### PR DESCRIPTION
Running the docker image built from the existing dockerfile doesn't allow users to provide args. Changing `CMD` to `ENTRYPOINT` allows users to initiate docker container along with command line args.

Example: `docker run --rm changeme -h` for help. `docker run --rm changeme x.x.x.x` to check default creds on x.x.x.x